### PR TITLE
(doc) Fix small issues in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="./resources/icon/icon.svg" align="left" alt="ChocoVersionSelect icon" width="64px" />
 
-ChocoVersionSelect is a Windows user interface for [Chocolatey](https://chocolatey.org) (the Machine Package Manager for Windows). Unlike [ChocolateyGUI](https://github.com/chocolatey/ChocolateyGUI), which has a broad set of features, ChocoVersionSelect is focused on managing t	he local installation of a *single package*. It does this by wrapping choco's `list`, `search`, and `upgrade` verbs.
+ChocoVersionSelect is a Windows user interface for [Chocolatey](https://chocolatey.org) (the Machine Package Manager for Windows). Unlike [Chocolatey GUI](https://github.com/chocolatey/ChocolateyGUI), which has a broad set of features, ChocoVersionSelect is focused on managing the local installation of a *single package*. It does this by wrapping choco's `list`, `search`, and `upgrade` verbs.
 ## Installation
 You can install ChocoVersionSelect from the [Chocolatey Community Respository](https://community.chocolatey.org/packages/chocoversionselect). If you already have it enabled as one of your packages sources, you can install it like this:
 ```
@@ -33,7 +33,7 @@ To end-user scenarios are envisaged:
 - Automatic refreshing and notification of new package availability using taskbar icon badge.
 - Multi-language support.
 ## Why does this exist?
-ChocoVersionSelect was created to address a specific use-case. Some users who are not comfortable using a command shell. Some users would be confused or endangered by the wide array of features in [ChocolateyGUI](https://github.com/chocolatey/ChocolateyGUI). ChocoVersionSelect lets them achieve all the package management they need with a minimal learning curve.
+ChocoVersionSelect was created to address a specific use-case. Some users who are not comfortable using a command shell. Some users would be confused or endangered by the wide array of features in [Chocolatey GUI](https://github.com/chocolatey/ChocolateyGUI). ChocoVersionSelect lets them achieve all the package management they need with a minimal learning curve.
 ## Dependencies
 ChocoVersionSelect does not have any build-time dependencies outside of the .NET 8.0 SDK. It won't do anything useful unless you already have [Chocolatey](https://chocolatey.org) installed and it can find choco.exe on the Windows [path](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/path).
 ## Source code notes


### PR DESCRIPTION
The application name is Chocolatey GUI not ChocolateyGUI.

There was a stray tab in the middle of a word, which I removed.